### PR TITLE
EASY-1252 - Sword2 deposits moeten DOI kunnen aanmaken en terugleveren

### DIFF
--- a/src/main/java/org/swordapp/server/AtomStatement.java
+++ b/src/main/java/org/swordapp/server/AtomStatement.java
@@ -3,9 +3,9 @@ package org.swordapp.server;
 import org.apache.abdera.Abdera;
 import org.apache.abdera.i18n.iri.IRI;
 import org.apache.abdera.model.Category;
-import org.apache.abdera.model.Element;
 import org.apache.abdera.model.Entry;
 import org.apache.abdera.model.Feed;
+import org.apache.abdera.model.Link;
 
 import javax.xml.namespace.QName;
 import java.io.IOException;
@@ -60,6 +60,10 @@ public class AtomStatement extends Statement {
             entry.setTitle("Resource " + resource.getUri());
             entry.setSummary("Resource Part");
             entry.setUpdated(new Date());
+
+            for (String linkHref : resource.getSelfLinks()) {
+                entry.addLink(linkHref, Link.REL_SELF);
+            }
         }
 
         // create an entry for each original deposit
@@ -74,6 +78,10 @@ public class AtomStatement extends Statement {
             entry.setTitle("Original Deposit " + deposit.getUri());
             entry.setSummary("Original Deposit");
             entry.setUpdated(new Date());
+
+            for (String linkHref : deposit.getSelfLinks()) {
+                entry.addLink(linkHref, Link.REL_SELF);
+            }
 
             entry.setContent(new IRI(deposit.getUri()), deposit.getMediaType());
             entry.addCategory(UriRegistry.SWORD_TERMS_NAMESPACE, UriRegistry.SWORD_ORIGINAL_DEPOSIT, "Original Deposit");

--- a/src/main/java/org/swordapp/server/ResourcePart.java
+++ b/src/main/java/org/swordapp/server/ResourcePart.java
@@ -1,12 +1,15 @@
 package org.swordapp.server;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.List;
 
 public class ResourcePart {
     protected String uri;
     protected String mediaType;
     protected Map<String, String> properties = new HashMap<String, String>();
+    protected List<String> selfLinks = new ArrayList<String>();
 
     public ResourcePart(String uri) {
         this.uri = uri;
@@ -31,4 +34,13 @@ public class ResourcePart {
     public void addProperty(String predicate, String object) {
         this.properties.put(predicate, object);
     }
+
+    public List<String> getSelfLinks() {
+        return selfLinks;
+    }
+
+    public void addSelfLink(String link) {
+        selfLinks.add(link);
+    }
+
 }


### PR DESCRIPTION
fixes EASY-1252 - Sword2 deposits moeten DOI kunnen aanmaken en terugleveren

#### When applied it will
* Added atom Links to the ResourcePart and updated the AtomStatement.writeTo to write them

#### Where should the reviewer @DANS-KNAW/easy start?
ResourcePart and AtomStatement.writeTo

#### How should this be manually tested?
The DOI url can be added as a 'selfLink' to the entry, this is done by the updated Sword2 implementation for the EASY-1252 issue. 

#### related pull requests on github
repo                       | PR
-------------------------- | -----------------
easy-                      | [PR#]() 