### PR TITLE
NO JIRA. Add method to access deposit's Content-Length header.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>nl.knaw.dans.easy</groupId>
     <artifactId>easy-sword2-lib</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>SWORD v2 Common Server Library (forked)</name>
     <description>

--- a/src/main/java/org/swordapp/server/Deposit.java
+++ b/src/main/java/org/swordapp/server/Deposit.java
@@ -19,6 +19,7 @@ public class Deposit {
     private boolean inProgress = false;
     private boolean metadataRelevant = true;
     private File file = null;
+    private long contentLength = -1L;
 
     public Deposit() {}
 
@@ -139,5 +140,13 @@ public class Deposit {
 
     public void setMetadataRelevant(boolean metadataRelevant) {
         this.metadataRelevant = metadataRelevant;
+    }
+
+    public void setContentLength(long length) {
+        this.contentLength = length;
+    }
+
+    public long getContentLength() {
+        return contentLength;
     }
 }

--- a/src/main/java/org/swordapp/server/SwordAPIEndpoint.java
+++ b/src/main/java/org/swordapp/server/SwordAPIEndpoint.java
@@ -298,6 +298,14 @@ public class SwordAPIEndpoint {
         if (packaging == null || "".equals(packaging)) {
             packaging = UriRegistry.PACKAGE_BINARY;
         }
+        long len = -1L;
+        if (req.getHeader("Content-Length") != null) {
+            try {
+                len = Long.parseLong(req.getHeader("Content-Length"));
+            }
+            catch (NumberFormatException e) {}
+        }
+
         InputStream file = req.getInputStream();
 
         // now let's interpret and deal with the headers that we have
@@ -311,6 +319,7 @@ public class SwordAPIEndpoint {
         deposit.setPackaging(packaging);
         deposit.setInputStream(file);
         deposit.setMimeType(contentType);
+        deposit.setContentLength(len);
 
         try {
             this.storeAndCheckBinary(deposit, this.config);


### PR DESCRIPTION
Adds a method to access the deposit's Content-Length header, so that it can be used to check in advance whether there is enough disk space to save the upload. Returns -1 if the header is not set.

#### Where should the reviewer @DANS-KNAW/easy start?

